### PR TITLE
Score Tally End Screen

### DIFF
--- a/Game/Globals/event_bus.gd
+++ b/Game/Globals/event_bus.gd
@@ -23,6 +23,10 @@ signal load_instructions
 ## closing the current scene in the process.
 signal load_credits
 
+## Indicates the game should switch to the Game Over scene,
+## closing the current scene in the process.
+signal load_game_over(score: int, best_streak: int)
+
 ## Emitted when the player presses the "confirm" button
 signal player_confirm
 

--- a/Game/Scenes/Game/game.gd
+++ b/Game/Scenes/Game/game.gd
@@ -62,8 +62,6 @@ func _end_game() -> void:
   _hud.show_game_end()
   _equation_board.toggle_cursor_sound(false)
   _equation_board.hide()
-  # TODO: Show something in the middle of the screen, as we wait to load Game Over
-  # "A Cheesy Delight!" ?
   await get_tree().create_timer(1.0).timeout
   EventBus.load_game_over.emit(_score_keeper.get_score(), _score_keeper.get_best_streak())
 

--- a/Game/Scenes/Game/game.gd
+++ b/Game/Scenes/Game/game.gd
@@ -65,10 +65,7 @@ func _end_game() -> void:
   _hud.show_game_end()
   _equation_board.toggle_cursor_sound(false)
   _equation_board.hide()
-  var high_score_beaten: bool = _score_keeper.get_score() > HighScore.get_current_high_score()
   #_game_over_canvas.show_game_over(high_score_beaten)
-  if high_score_beaten:
-    HighScore.save_new_high_score(_score_keeper.get_score())
   # TODO: Show something in the middle of the screen, as we wait to load Game Over
   # "A Cheesy Delight!" ?
   await get_tree().create_timer(1.0).timeout

--- a/Game/Scenes/Game/game.gd
+++ b/Game/Scenes/Game/game.gd
@@ -66,9 +66,13 @@ func _end_game() -> void:
   _equation_board.toggle_cursor_sound(false)
   _equation_board.hide()
   var high_score_beaten: bool = _score_keeper.get_score() > HighScore.get_current_high_score()
-  _game_over_canvas.show_game_over(high_score_beaten)
+  #_game_over_canvas.show_game_over(high_score_beaten)
   if high_score_beaten:
     HighScore.save_new_high_score(_score_keeper.get_score())
+  # TODO: Show something in the middle of the screen, as we wait to load Game Over
+  # "A Cheesy Delight!" ?
+  await get_tree().create_timer(1.0).timeout
+  EventBus.load_game_over.emit(_score_keeper.get_score(), _score_keeper.get_best_streak())
 
 func _on_board_equation_selected(equation: Equation) -> void:
   if !_game_on or equation == null:

--- a/Game/Scenes/Game/game.gd
+++ b/Game/Scenes/Game/game.gd
@@ -8,7 +8,6 @@ extends Node
 @onready var _countdown_timer: Timer = $CountdownTimer
 @onready var _countdown_label: Label = $CountdownLabel
 @onready var _pause_screen: PauseScreen = $PauseScreen
-@onready var _game_over_canvas: GameOverCanvas = $GameOverCanvas
 @onready var _wrong_sound: SoundEffect = $WrongSound
 @onready var _correct_sound: SoundEffect = $CorrectSound
 @onready var _new_high_score_sound: SoundEffect = $NewHighScoreSound
@@ -25,7 +24,6 @@ var _high_score_reached: bool = false
 func _ready() -> void:
   _start_new_game()
   _toggle_game_piece_visibility(false)
-  _game_over_canvas.hide()
   _score_keeper.score_updated.connect(_hud.update_score_display)
 
 func _process(_delta: float) -> void:
@@ -51,7 +49,6 @@ func _start_new_game() -> void:
   _high_score_reached = false
   _hud.update_time_display(_game_timer.wait_time)
   _hud.update_high_score_display(HighScore.get_current_high_score())
-  _game_over_canvas.hide()
   _generate_new_equations()
   await _run_countdown_async()
   _equation_board.toggle_cursor_sound(true)
@@ -65,7 +62,6 @@ func _end_game() -> void:
   _hud.show_game_end()
   _equation_board.toggle_cursor_sound(false)
   _equation_board.hide()
-  #_game_over_canvas.show_game_over(high_score_beaten)
   # TODO: Show something in the middle of the screen, as we wait to load Game Over
   # "A Cheesy Delight!" ?
   await get_tree().create_timer(1.0).timeout

--- a/Game/Scenes/Game/game.gd
+++ b/Game/Scenes/Game/game.gd
@@ -10,7 +10,7 @@ extends Node
 @onready var _pause_screen: PauseScreen = $PauseScreen
 @onready var _wrong_sound: SoundEffect = $WrongSound
 @onready var _correct_sound: SoundEffect = $CorrectSound
-@onready var _new_high_score_sound: SoundEffect = $NewHighScoreSound
+@onready var _streak_reached_sound: SoundEffect = $StreakReachedSound
 @onready var _score_keeper: ScoreKeeper = ScoreKeeper.new()
 
 var _answer_to_hit: int:
@@ -71,23 +71,15 @@ func _on_board_equation_selected(equation: Equation) -> void:
   if !_game_on or equation == null:
     return
   if _answer_to_hit == equation.get_answer():
-    _score_keeper.score_hit()
-    if _score_keeper.get_score() > HighScore.get_current_high_score():
-      if not _high_score_reached:
-        _new_high_score_sound.play()
-        _high_score_reached = true
-      else:
-        _correct_sound.play()
-      _hud.update_high_score_display(_score_keeper.get_score(), true)
+    var streak_reached: bool = _score_keeper.score_hit()
+    if streak_reached:
+      _streak_reached_sound.play()
     else:
       _correct_sound.play()
   else:
     _wrong_sound.play()
     _score_keeper.score_miss()
-    if _score_keeper.get_score() <= HighScore.get_current_high_score():
-      _hud.update_high_score_display(HighScore.get_current_high_score(), false)
-    else:
-      _hud.update_high_score_display(_score_keeper.get_score(), true)
+    _hud.update_high_score_display(HighScore.get_current_high_score())
   _generate_new_equations()
 
 func _on_game_timer_timeout() -> void:

--- a/Game/Scenes/Game/game.tscn
+++ b/Game/Scenes/Game/game.tscn
@@ -61,7 +61,7 @@ stream = ExtResource("6_vifcx")
 script = ExtResource("10_7jvlm")
 metadata/_custom_type_script = "uid://cva0agtacaluv"
 
-[node name="NewHighScoreSound" type="AudioStreamPlayer" parent="."]
+[node name="StreakReachedSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("9_huoen")
 script = ExtResource("10_7jvlm")
 metadata/_custom_type_script = "uid://cva0agtacaluv"

--- a/Game/Scenes/Game/game.tscn
+++ b/Game/Scenes/Game/game.tscn
@@ -72,6 +72,5 @@ metadata/_custom_type_script = "uid://cva0agtacaluv"
 
 [connection signal="timeout" from="GameTimer" to="." method="_on_game_timer_timeout"]
 [connection signal="board_equation_selected" from="EquationBoard" to="." method="_on_board_equation_selected"]
-[connection signal="play_again_requested" from="GameOverCanvas" to="." method="_on_play_again_requested"]
 [connection signal="paused" from="PauseScreen" to="." method="_on_pause_screen_paused"]
 [connection signal="unpaused" from="PauseScreen" to="." method="_on_pause_screen_unpaused"]

--- a/Game/Scenes/Game/game.tscn
+++ b/Game/Scenes/Game/game.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=11 format=3 uid="uid://55o2ddpjh5ds"]
+[gd_scene load_steps=10 format=3 uid="uid://55o2ddpjh5ds"]
 
 [ext_resource type="Script" uid="uid://lv7n6cdct43x" path="res://Scenes/Game/game.gd" id="1_i1e5p"]
 [ext_resource type="PackedScene" uid="uid://cfdil1vt2522f" path="res://Scenes/HUD/hud.tscn" id="2_i1e5p"]
 [ext_resource type="PackedScene" uid="uid://c5b1rrrdeysj3" path="res://Scenes/EquationBoard/equation_board.tscn" id="3_flgk0"]
 [ext_resource type="PackedScene" uid="uid://bya2bspfpyt0c" path="res://Scenes/BlueyAnswer/bluey_answer.tscn" id="4_vifcx"]
-[ext_resource type="PackedScene" uid="uid://dqtfvuspfhidd" path="res://Scenes/Game/game_over_canvas.tscn" id="5_7jvlm"]
 [ext_resource type="AudioStream" uid="uid://7cc2l76edtum" path="res://Assets/Sounds/wrong.wav" id="5_ciybh"]
 [ext_resource type="PackedScene" uid="uid://csme42t8hpnid" path="res://Scenes/PauseScreen/pause_screen.tscn" id="6_flgk0"]
 [ext_resource type="AudioStream" uid="uid://c42nkfhvunfly" path="res://Assets/Sounds/correct.wav" id="6_vifcx"]
@@ -27,9 +26,6 @@ position = Vector2(288, 192)
 [node name="BlueyAnswer" parent="." groups=["GamePieces"] instance=ExtResource("4_vifcx")]
 visible = false
 position = Vector2(616, 576)
-
-[node name="GameOverCanvas" parent="." instance=ExtResource("5_7jvlm")]
-visible = false
 
 [node name="CountdownLabel" type="Label" parent="."]
 visible = false

--- a/Game/Scenes/Game/game_over_canvas.gd
+++ b/Game/Scenes/Game/game_over_canvas.gd
@@ -1,8 +1,6 @@
 class_name GameOverCanvas
 extends CanvasLayer
 
-signal play_again_requested
-
 @onready var _game_over_label: Label = $GameOverLabel
 @onready var _restart_button: EnhancedButton = $RestartButton
 @onready var _main_menu_button: EnhancedButton = $MainMenuButton
@@ -41,7 +39,7 @@ func _disable_game_end_buttons_momentarily() -> void:
   _main_menu_button.disabled = false
 
 func _on_restart_button_pressed() -> void:
-  play_again_requested.emit()
+  EventBus.load_game.emit()
 
 func _on_main_menu_button_pressed() -> void:
   EventBus.load_main_menu.emit()

--- a/Game/Scenes/Game/score_keeper.gd
+++ b/Game/Scenes/Game/score_keeper.gd
@@ -6,7 +6,9 @@ const _BASE_REWARD: int = 100
 const _BASE_PENALTY: int = 50
 const _HOT_STREAK_THRESHOLD: int = 2
 
-var _current_score: int
+var _current_score: int:
+  set(value):
+    _current_score = max(_current_score + value, 0)
 var _current_streak: int
 var _best_streak: int
 

--- a/Game/Scenes/Game/score_keeper.gd
+++ b/Game/Scenes/Game/score_keeper.gd
@@ -8,12 +8,16 @@ const _HOT_STREAK_THRESHOLD: int = 2
 
 var _current_score: int
 var _current_streak: int
+var _best_streak: int
 
 func get_score() -> int:
   return _current_score
 
 func get_streak() -> int:
   return _current_streak
+
+func get_best_streak() -> int:
+  return _best_streak;
 
 func on_hot_streak() -> bool:
   return _current_streak > _HOT_STREAK_THRESHOLD
@@ -25,6 +29,8 @@ func score_hit() -> void:
     _current_score += _BASE_REWARD + streak_bonus
   else:
     _current_score += _BASE_REWARD
+  if _current_streak > _best_streak:
+    _best_streak = _current_streak
   _notify_score_updated()
 
 func score_miss() -> void:
@@ -35,6 +41,7 @@ func score_miss() -> void:
 func reset() -> void:
   _current_score = 0
   _current_streak = 0
+  _best_streak = 0
   _notify_score_updated()
 
 func _notify_score_updated() -> void:

--- a/Game/Scenes/Game/score_keeper.gd
+++ b/Game/Scenes/Game/score_keeper.gd
@@ -24,7 +24,7 @@ func get_best_streak() -> int:
 func on_hot_streak() -> bool:
   return _current_streak > _HOT_STREAK_THRESHOLD
 
-func score_hit() -> void:
+func score_hit() -> bool:
   _current_streak += 1
   if on_hot_streak():
     var streak_bonus: int = ceili(_BASE_REWARD * _current_streak * 0.15)
@@ -34,6 +34,7 @@ func score_hit() -> void:
   if _current_streak > _best_streak:
     _best_streak = _current_streak
   _notify_score_updated()
+  return _current_streak == _HOT_STREAK_THRESHOLD + 1
 
 func score_miss() -> void:
   _current_score -= _BASE_PENALTY

--- a/Game/Scenes/Game/score_keeper.gd
+++ b/Game/Scenes/Game/score_keeper.gd
@@ -8,7 +8,7 @@ const _HOT_STREAK_THRESHOLD: int = 2
 
 var _current_score: int:
   set(value):
-    _current_score = max(_current_score + value, 0)
+    _current_score = max(value, 0)
 var _current_streak: int
 var _best_streak: int
 

--- a/Game/Scenes/GameOverScreen/game_over_screen.gd
+++ b/Game/Scenes/GameOverScreen/game_over_screen.gd
@@ -1,8 +1,36 @@
 class_name GameOverScreen
 extends Control
 
+## How many points to award per number in the Best Streak
+@export var best_streak_bonus_unit: int = 1000
+
+@onready var _score_value: Label = %ScoreValue
+@onready var _streak_score_value: Label = %StreakScoreValue
+@onready var _streak_value: Label = %StreakValue
+@onready var _total_value: Label = %TotalValue
+
+@onready var _score_line: HBoxContainer = %ScoreHBox
+@onready var _streak_line: HBoxContainer = %StreakHBox
+@onready var _sum_line: Line2D = %SumLine
+@onready var _total_line: HBoxContainer = %TotalHBox
+
 var _score: int
+var _streak_score: int
+var _total_score: int
 var _best_streak: int
+
+var _current_streak_score: int:
+  set(value):
+    _current_streak_score = value
+    _streak_score_value.text = "%d" % value
+var _current_total_score: int:
+  set(value):
+    _current_total_score = value
+    _total_value.text = "%d" % value
+
+var _tallying: bool
+var _waited_for_total: bool
+var _done_tallying: bool
 
 func load_scene_data(data: Variant) -> void:
   # data is Array[int]
@@ -10,4 +38,49 @@ func load_scene_data(data: Variant) -> void:
   _best_streak = data[1]
 
 func _ready() -> void:
-  print("Score! %d | Best Streak! %d" % [_score, _best_streak])
+  # Debug
+  _score = 100000
+  _best_streak = 20
+
+  _score_line.hide()
+  _streak_line.hide()
+  _sum_line.hide()
+  _total_line.hide()
+  _score_value.text = "%d" % _score
+  _streak_value.text = "%03d" % _best_streak
+  _streak_score_value.text = "0"
+  _total_value.text = "0"
+  _streak_score = _best_streak * best_streak_bonus_unit
+  _total_score = _score + _streak_score
+  await get_tree().create_timer(.5).timeout
+  _score_line.show()
+  await get_tree().create_timer(.5).timeout
+  _tallying = true
+
+func _process(_delta: float) -> void:
+  if not _done_tallying:
+    _try_tally()
+  else:
+    pass
+    # Show high score congrats, or general 'game over' message
+    # Show Play Again / Back to Menu buttons
+
+func _try_tally() -> void:
+  if not _tallying:
+    return
+  if _current_streak_score < _streak_score:
+    if not _streak_line.visible:
+      _streak_line.show()
+    _current_streak_score = (clamp(_current_streak_score + round(best_streak_bonus_unit / 2), 0, _streak_score))
+    return
+  if not _waited_for_total:
+    await get_tree().create_timer(.5).timeout
+    _waited_for_total = true
+  if _current_total_score < _total_score:
+    if not _total_line.visible:
+      _sum_line.show()
+      _total_line.show()
+    _current_total_score = clampi(_current_total_score + 1039, 0, _total_score)
+  else:
+    _tallying = false
+    _done_tallying = true

--- a/Game/Scenes/GameOverScreen/game_over_screen.gd
+++ b/Game/Scenes/GameOverScreen/game_over_screen.gd
@@ -17,10 +17,15 @@ extends Control
 @onready var _score_line_timer: Timer = $ScoreLineTimer
 @onready var _tally_timer: Timer = $StreakTallyTimer
 
+@onready var _game_over_canvas: GameOverCanvas = $GameOverCanvas
+
+@onready var _tally_sound: SoundEffect = $TallySound
+@onready var _high_score_reached_sound: SoundEffect = $HighScoreReachedSound
+
 var _score: int
+var _best_streak: int
 var _streak_score: int
 var _total_score: int
-var _best_streak: int
 
 var _current_streak_score: int:
   set(value):
@@ -37,43 +42,51 @@ func load_scene_data(data: Variant) -> void:
   _best_streak = data[1]
 
 func _ready() -> void:
-  load_scene_data([100000, 20]) # Debug
+  load_scene_data([100000, 25]) # Debug
   _streak_score = _best_streak * best_streak_bonus_unit
   _total_score = _score + _streak_score
+  var high_score_reached: bool = _total_score > HighScore.get_current_high_score()
   _initialize_tally_display()
   await _tally_async()
-  print("Done!")
-  # TODO: Show 'high score congrats' or 'thanks for playing' message
-  # TODO: Show 'play again' and 'back to menu' buttons
+
+  if high_score_reached:
+    HighScore.save_new_high_score(_total_score)
+    _high_score_reached_sound.play()
+  _game_over_canvas.show_game_over(high_score_reached)
 
 func _initialize_tally_display() -> void:
   _score_line.hide()
   _streak_line.hide()
   _sum_line.hide()
   _total_line.hide()
+  _game_over_canvas.hide()
   _score_value.text = "%d" % _score
   _streak_value.text = "%03d" % _best_streak
   _streak_score_value.text = "0"
   _total_value.text = "0"
 
 func _tally_async() -> void:
-  _score_line_timer.start()
-  await _score_line_timer.timeout
+  await _restart_score_line_timer_async()
   _score_line.show()
-  _score_line_timer.start()
-  await _score_line_timer.timeout
+  await _restart_score_line_timer_async()
   _streak_line.show()
   while _current_streak_score < _streak_score:
     var increment: int = _current_streak_score + best_streak_bonus_unit
     _tally_timer.start()
     await _tally_timer.timeout
+    _tally_sound.play()
     _current_streak_score = clampi(increment, 0, _streak_score)
-  _score_line_timer.start()
-  await _score_line_timer.timeout
+  await _restart_score_line_timer_async()
   _sum_line.show()
   _total_line.show()
   while _current_total_score < _total_score:
     var increment: int = _current_total_score + 5276
     _tally_timer.start()
     await _tally_timer.timeout
+    _tally_sound.play()
     _current_total_score = clampi(increment, 0, _total_score)
+  await _restart_score_line_timer_async()
+
+func _restart_score_line_timer_async() -> void:
+  _score_line_timer.start()
+  await _score_line_timer.timeout

--- a/Game/Scenes/GameOverScreen/game_over_screen.gd
+++ b/Game/Scenes/GameOverScreen/game_over_screen.gd
@@ -1,0 +1,2 @@
+class_name GameOverScreen
+extends Control

--- a/Game/Scenes/GameOverScreen/game_over_screen.gd
+++ b/Game/Scenes/GameOverScreen/game_over_screen.gd
@@ -1,2 +1,13 @@
 class_name GameOverScreen
 extends Control
+
+var _score: int
+var _best_streak: int
+
+func load_scene_data(data: Variant) -> void:
+  # data is Array[int]
+  _score = data[0]
+  _best_streak = data[1]
+
+func _ready() -> void:
+  print("Score! %d | Best Streak! %d" % [_score, _best_streak])

--- a/Game/Scenes/GameOverScreen/game_over_screen.gd
+++ b/Game/Scenes/GameOverScreen/game_over_screen.gd
@@ -2,7 +2,7 @@ class_name GameOverScreen
 extends Control
 
 ## How many points to award per number in the Best Streak
-@export var best_streak_bonus_unit: int = 1000
+@export var best_streak_bonus_unit: int = 100
 
 @onready var _score_value: Label = %ScoreValue
 @onready var _streak_score_value: Label = %StreakScoreValue

--- a/Game/Scenes/GameOverScreen/game_over_screen.gd
+++ b/Game/Scenes/GameOverScreen/game_over_screen.gd
@@ -42,7 +42,6 @@ func load_scene_data(data: Variant) -> void:
   _best_streak = data[1]
 
 func _ready() -> void:
-  load_scene_data([100000, 25]) # Debug
   _streak_score = _best_streak * best_streak_bonus_unit
   _total_score = _score + _streak_score
   var high_score_reached: bool = _total_score > HighScore.get_current_high_score()
@@ -52,6 +51,8 @@ func _ready() -> void:
   if high_score_reached:
     HighScore.save_new_high_score(_total_score)
     _high_score_reached_sound.play()
+    # TODO: Make the high score highlight color common. HighScore class?
+    _total_value.add_theme_color_override("font_color", Color.GREEN)
   _game_over_canvas.show_game_over(high_score_reached)
 
 func _initialize_tally_display() -> void:

--- a/Game/Scenes/GameOverScreen/game_over_screen.gd
+++ b/Game/Scenes/GameOverScreen/game_over_screen.gd
@@ -14,6 +14,9 @@ extends Control
 @onready var _sum_line: Line2D = %SumLine
 @onready var _total_line: HBoxContainer = %TotalHBox
 
+@onready var _score_line_timer: Timer = $ScoreLineTimer
+@onready var _tally_timer: Timer = $StreakTallyTimer
+
 var _score: int
 var _streak_score: int
 var _total_score: int
@@ -28,20 +31,22 @@ var _current_total_score: int:
     _current_total_score = value
     _total_value.text = "%d" % value
 
-var _tallying: bool
-var _waited_for_total: bool
-var _done_tallying: bool
-
 func load_scene_data(data: Variant) -> void:
   # data is Array[int]
   _score = data[0]
   _best_streak = data[1]
 
 func _ready() -> void:
-  # Debug
-  _score = 100000
-  _best_streak = 20
+  load_scene_data([100000, 20]) # Debug
+  _streak_score = _best_streak * best_streak_bonus_unit
+  _total_score = _score + _streak_score
+  _initialize_tally_display()
+  await _tally_async()
+  print("Done!")
+  # TODO: Show 'high score congrats' or 'thanks for playing' message
+  # TODO: Show 'play again' and 'back to menu' buttons
 
+func _initialize_tally_display() -> void:
   _score_line.hide()
   _streak_line.hide()
   _sum_line.hide()
@@ -50,37 +55,25 @@ func _ready() -> void:
   _streak_value.text = "%03d" % _best_streak
   _streak_score_value.text = "0"
   _total_value.text = "0"
-  _streak_score = _best_streak * best_streak_bonus_unit
-  _total_score = _score + _streak_score
-  await get_tree().create_timer(.5).timeout
+
+func _tally_async() -> void:
+  _score_line_timer.start()
+  await _score_line_timer.timeout
   _score_line.show()
-  await get_tree().create_timer(.5).timeout
-  _tallying = true
-
-func _process(_delta: float) -> void:
-  if not _done_tallying:
-    _try_tally()
-  else:
-    pass
-    # Show high score congrats, or general 'game over' message
-    # Show Play Again / Back to Menu buttons
-
-func _try_tally() -> void:
-  if not _tallying:
-    return
-  if _current_streak_score < _streak_score:
-    if not _streak_line.visible:
-      _streak_line.show()
-    _current_streak_score = (clamp(_current_streak_score + round(best_streak_bonus_unit / 2), 0, _streak_score))
-    return
-  if not _waited_for_total:
-    await get_tree().create_timer(.5).timeout
-    _waited_for_total = true
-  if _current_total_score < _total_score:
-    if not _total_line.visible:
-      _sum_line.show()
-      _total_line.show()
-    _current_total_score = clampi(_current_total_score + 1039, 0, _total_score)
-  else:
-    _tallying = false
-    _done_tallying = true
+  _score_line_timer.start()
+  await _score_line_timer.timeout
+  _streak_line.show()
+  while _current_streak_score < _streak_score:
+    var increment: int = _current_streak_score + best_streak_bonus_unit
+    _tally_timer.start()
+    await _tally_timer.timeout
+    _current_streak_score = clampi(increment, 0, _streak_score)
+  _score_line_timer.start()
+  await _score_line_timer.timeout
+  _sum_line.show()
+  _total_line.show()
+  while _current_total_score < _total_score:
+    var increment: int = _current_total_score + 5276
+    _tally_timer.start()
+    await _tally_timer.timeout
+    _current_total_score = clampi(increment, 0, _total_score)

--- a/Game/Scenes/GameOverScreen/game_over_screen.gd.uid
+++ b/Game/Scenes/GameOverScreen/game_over_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://bobwum3kiiunl

--- a/Game/Scenes/GameOverScreen/game_over_screen.tscn
+++ b/Game/Scenes/GameOverScreen/game_over_screen.tscn
@@ -10,3 +10,86 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_c00pi")
+
+[node name="ScoreSummaryVBox" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -311.5
+offset_top = -103.5
+offset_right = 311.5
+offset_bottom = 103.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ScoreHBox" type="HBoxContainer" parent="ScoreSummaryVBox"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="ScoreText" type="Label" parent="ScoreSummaryVBox/ScoreHBox"]
+custom_minimum_size = Vector2(300, 0)
+layout_mode = 2
+text = "Score"
+uppercase = true
+max_lines_visible = 1
+
+[node name="ScoreValue" type="Label" parent="ScoreSummaryVBox/ScoreHBox"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(205, 0)
+layout_mode = 2
+text = "00000000"
+horizontal_alignment = 2
+max_lines_visible = 1
+
+[node name="StreakHBox" type="HBoxContainer" parent="ScoreSummaryVBox"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="StreakText" type="Label" parent="ScoreSummaryVBox/StreakHBox"]
+custom_minimum_size = Vector2(300, 0)
+layout_mode = 2
+text = "Best Streak"
+uppercase = true
+max_lines_visible = 1
+
+[node name="StreakScoreValue" type="Label" parent="ScoreSummaryVBox/StreakHBox"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(205, 0)
+layout_mode = 2
+text = "00000000"
+horizontal_alignment = 2
+max_lines_visible = 1
+
+[node name="StreakValue" type="Label" parent="ScoreSummaryVBox/StreakHBox"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 10
+text = "000"
+
+[node name="SumLine" type="Line2D" parent="ScoreSummaryVBox"]
+unique_name_in_owner = true
+position = Vector2(7, 144)
+points = PackedVector2Array(-15.5, -6.5, 512.5, -6.5)
+width = 5.0
+
+[node name="TotalHBox" type="HBoxContainer" parent="ScoreSummaryVBox"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="TotalText" type="Label" parent="ScoreSummaryVBox/TotalHBox"]
+custom_minimum_size = Vector2(300, 0)
+layout_mode = 2
+text = "Total"
+uppercase = true
+max_lines_visible = 1
+
+[node name="TotalValue" type="Label" parent="ScoreSummaryVBox/TotalHBox"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(205, 0)
+layout_mode = 2
+text = "00000000"
+horizontal_alignment = 2
+max_lines_visible = 1

--- a/Game/Scenes/GameOverScreen/game_over_screen.tscn
+++ b/Game/Scenes/GameOverScreen/game_over_screen.tscn
@@ -93,3 +93,11 @@ layout_mode = 2
 text = "00000000"
 horizontal_alignment = 2
 max_lines_visible = 1
+
+[node name="StreakTallyTimer" type="Timer" parent="."]
+wait_time = 0.05
+one_shot = true
+
+[node name="ScoreLineTimer" type="Timer" parent="."]
+wait_time = 0.5
+one_shot = true

--- a/Game/Scenes/GameOverScreen/game_over_screen.tscn
+++ b/Game/Scenes/GameOverScreen/game_over_screen.tscn
@@ -1,6 +1,10 @@
-[gd_scene load_steps=2 format=3 uid="uid://btspuodtkbr7u"]
+[gd_scene load_steps=6 format=3 uid="uid://btspuodtkbr7u"]
 
 [ext_resource type="Script" uid="uid://bobwum3kiiunl" path="res://Scenes/GameOverScreen/game_over_screen.gd" id="1_c00pi"]
+[ext_resource type="PackedScene" uid="uid://dqtfvuspfhidd" path="res://Scenes/Game/game_over_canvas.tscn" id="2_clcq5"]
+[ext_resource type="AudioStream" uid="uid://dj2td4g4rgj06" path="res://Assets/Sounds/move_cursor.wav" id="3_pysk1"]
+[ext_resource type="Script" uid="uid://cva0agtacaluv" path="res://Scenes/SoundEffect/sound_effect.gd" id="4_fgskh"]
+[ext_resource type="AudioStream" uid="uid://dbv00fxfs8fif" path="res://Assets/Sounds/new_high_score.wav" id="5_fgskh"]
 
 [node name="GameOverScreen" type="Control"]
 layout_mode = 3
@@ -13,17 +17,14 @@ script = ExtResource("1_c00pi")
 
 [node name="ScoreSummaryVBox" type="VBoxContainer" parent="."]
 layout_mode = 1
-anchors_preset = 8
+anchors_preset = 5
 anchor_left = 0.5
-anchor_top = 0.5
 anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -311.5
-offset_top = -103.5
-offset_right = 311.5
-offset_bottom = 103.5
+offset_left = -335.5
+offset_top = 60.0
+offset_right = 335.5
+offset_bottom = 267.0
 grow_horizontal = 2
-grow_vertical = 2
 
 [node name="ScoreHBox" type="HBoxContainer" parent="ScoreSummaryVBox"]
 unique_name_in_owner = true
@@ -63,6 +64,11 @@ text = "00000000"
 horizontal_alignment = 2
 max_lines_visible = 1
 
+[node name="Separator" type="Label" parent="ScoreSummaryVBox/StreakHBox"]
+layout_mode = 2
+size_flags_horizontal = 10
+text = "  x"
+
 [node name="StreakValue" type="Label" parent="ScoreSummaryVBox/StreakHBox"]
 unique_name_in_owner = true
 layout_mode = 2
@@ -101,3 +107,26 @@ one_shot = true
 [node name="ScoreLineTimer" type="Timer" parent="."]
 wait_time = 0.5
 one_shot = true
+
+[node name="GameOverCanvas" parent="." instance=ExtResource("2_clcq5")]
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -20.0
+offset_right = 20.0
+offset_bottom = 65.0
+grow_horizontal = 2
+text = "Game Over"
+
+[node name="TallySound" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("3_pysk1")
+script = ExtResource("4_fgskh")
+metadata/_custom_type_script = "uid://cva0agtacaluv"
+
+[node name="HighScoreReachedSound" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("5_fgskh")
+script = ExtResource("4_fgskh")
+metadata/_custom_type_script = "uid://cva0agtacaluv"

--- a/Game/Scenes/GameOverScreen/game_over_screen.tscn
+++ b/Game/Scenes/GameOverScreen/game_over_screen.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3 uid="uid://btspuodtkbr7u"]
+
+[ext_resource type="Script" uid="uid://bobwum3kiiunl" path="res://Scenes/GameOverScreen/game_over_screen.gd" id="1_c00pi"]
+
+[node name="GameOverScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_c00pi")

--- a/Game/Scenes/HUD/hud.gd
+++ b/Game/Scenes/HUD/hud.gd
@@ -10,12 +10,8 @@ func update_score_display(new_score: int, new_streak: int, on_hot_streak: bool) 
   _update_score_display(new_score)
   _update_streak_display(new_streak, on_hot_streak)
 
-func update_high_score_display(high_score: int, highlight: bool = false) -> void:
+func update_high_score_display(high_score: int) -> void:
   _high_score_label.text = _clamp_score_display(high_score)
-  if highlight:
-    _high_score_label.add_theme_color_override("font_color", Color.GREEN)
-  else:
-    _high_score_label.remove_theme_color_override("font_color")
 
 func update_time_display(time_remaining: float) -> void:
   var format: String = "%2d"

--- a/Game/Scenes/Root/root.gd
+++ b/Game/Scenes/Root/root.gd
@@ -7,6 +7,7 @@ const OPTIONS_SCENE: PackedScene = preload("res://Scenes/OptionsScreen/options_s
 const GAME_SCENE: PackedScene = preload("res://Scenes/Game/game.tscn")
 const INSTRUCTIONS_SCENE: PackedScene = preload("res://Scenes/InstructionsScreen/instructions_screen.tscn")
 const CREDITS_SCENE: PackedScene = preload("res://Scenes/Credits/credits.tscn")
+const GAME_OVER_SCENE: PackedScene = preload("res://Scenes/GameOverScreen/game_over_screen.tscn")
 
 @onready var _scene_loader: SceneLoader = $SceneLoader
 @onready var _backgroud_parallex: Parallax2D = $BackgroundParallex
@@ -18,6 +19,7 @@ func _ready() -> void:
   EventBus.load_game.connect(_load_game)
   EventBus.load_instructions.connect(_load_instructions)
   EventBus.load_credits.connect(_load_credits)
+  EventBus.load_game_over.connect(_load_game_over)
 
 func _load_main_menu() -> void:
   await _scene_loader.queue_load(MAIN_MENU_SCENE)
@@ -34,9 +36,11 @@ func _load_instructions() -> void:
 func _load_credits() -> void:
   await _scene_loader.queue_load(CREDITS_SCENE)
 
+func _load_game_over(_score: int, _best_streak: int) -> void:
+  await _scene_loader.queue_load(GAME_OVER_SCENE, [_score, _best_streak])
+
 func _on_scene_loader_instance_loaded(loaded_scene: PackedScene, _loaded_instance: Node) -> void:
-  _backgroud_parallex.visible =\
-    loaded_scene == MAIN_MENU_SCENE or\
-    loaded_scene == CREDITS_SCENE or\
-    loaded_scene == INSTRUCTIONS_SCENE or\
-    loaded_scene == OPTIONS_SCENE
+  var hide_parallex: bool =\
+    loaded_scene == SPLASH_SCREEN_SCENE or\
+    loaded_scene == GAME_SCENE
+  _backgroud_parallex.visible = !hide_parallex

--- a/Game/Scenes/Root/scene_loader.gd
+++ b/Game/Scenes/Root/scene_loader.gd
@@ -6,6 +6,7 @@ extends Node
 
 var _loaded_instance: Node
 var _scene_to_load: PackedScene
+var _data_for_scene_to_load: Variant
 var _load_queued: bool:
   get: return _scene_to_load != null
 
@@ -16,10 +17,11 @@ signal instance_loaded(loaded_scene: PackedScene, loaded_instance: Node)
 ## be unloaded properly before this scene will load.
 ## If another PackedScene was queued for loading but never got loaded,
 ## this new call will take priority.
-func queue_load(scene: PackedScene) -> void:
+func queue_load(scene: PackedScene, data_for_scene: Variant = null) -> void:
   # HACK: Allow any sound effects to play
   await get_tree().create_timer(.15).timeout
   _scene_to_load = scene;
+  _data_for_scene_to_load = data_for_scene
 
 func _process(_delta: float) -> void:
   if !_load_queued:
@@ -32,9 +34,28 @@ func _process(_delta: float) -> void:
 
 func _load_instance() -> void:
   _loaded_instance = _scene_to_load.instantiate()
+  # If we're given data to pass along, and the scene has func "load_scene_data(data: Variant)", call it
+  if _data_for_scene_to_load != null && _instance_has_load_scene_data_method(_loaded_instance):
+    @warning_ignore("unsafe_method_access")
+    _loaded_instance.load_scene_data(_data_for_scene_to_load)
   get_parent().add_child(_loaded_instance)
   instance_loaded.emit(_scene_to_load, _loaded_instance)
 
 func _try_unload_instance() -> void:
   if _loaded_instance != null and is_instance_valid(_loaded_instance):
     _loaded_instance.queue_free()
+
+func _instance_has_load_scene_data_method(instance: Node) -> bool:
+  var methods: Array[Dictionary] = instance.get_method_list()
+  var load_method_metadata: Dictionary
+  for method: Dictionary in methods:
+    if method["name"] == "load_scene_data":
+      load_method_metadata = method
+      break
+  if not load_method_metadata:
+    return false
+  var args: Array[Dictionary] = load_method_metadata["args"]
+  if args.size() != 1:
+    return false
+  var argument: Dictionary = args[0]
+  return argument["name"] == "data" and argument["type"] == TYPE_NIL


### PR DESCRIPTION
- Relates to #14 
- Adds score bonus for "Best Streak" (100 * streak reached)
- Audibly tallies up the score
- High Score Highlighting moved to Game Over screen
  - "High Score" sound now plays when you first reach a streak instead
- When loading a scene via the Scene Loader, can now optionally pass data along for the ride